### PR TITLE
Fix gcc compilation error

### DIFF
--- a/c++/triqs_ctseg/logs.hpp
+++ b/c++/triqs_ctseg/logs.hpp
@@ -24,9 +24,6 @@ static constexpr bool print_logs = false;
 #include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 
-#include <nda/nda.hpp>
-template <nda::MemoryArray A> struct fmt::formatter<A> : ostream_formatter {};
-
 // Log messages for dubugging
 #define LOG(...) SPDLOG_DEBUG(__VA_ARGS__)
 


### PR DESCRIPTION
gcc complains about the specialized `fmt::formatter` for `nda::MemoryArray` types:

```
#11 22.62 /source/ctseg/c++/triqs_ctseg/logs.hpp:28:43: error: declaration of 'struct fmt::v12::formatter<T>' ambiguates earlier template instantiation for 'struct fmt::v12::formatter<nda::basic_array<double, 1, nda::C_layout, 'V', nda::heap_basic<nda::mem::mallocator<> > >, char, void>' [-fpermissive]
#11 22.62    28 | template <nda::MemoryArray A> struct fmt::formatter<A> : ostream_formatter {};
#11 22.62       |                                           ^~~~~~~~~~~~
```

Since we are already using `fmt::streamed` (see https://github.com/TRIQS/ctseg/commit/12f816cc5f29726273fe73c08d90779f10b29812), I don't think we actually need the formatter. Removing it should be fine and should fix the compilation error.