### PR TITLE
Handle complex-flagged h_loc0: take real part within imag_threshold

### DIFF
--- a/c++/triqs_ctseg/params.cpp
+++ b/c++/triqs_ctseg/params.cpp
@@ -75,6 +75,7 @@ namespace triqs_ctseg {
     h5_write(grp, "measure_state_hist", c.measure_state_hist);
     h5_write(grp, "measure_g2w", c.measure_g2w);
     h5_write(grp, "measure_g3w", c.measure_g3w);
+    h5_write(grp, "imag_threshold", c.imag_threshold);
     h5_write(grp, "det_init_size", c.det_init_size);
     h5_write(grp, "det_n_operations_before_check", c.det_n_operations_before_check);
     h5_write(grp, "det_precision_warning", c.det_precision_warning);
@@ -127,6 +128,7 @@ namespace triqs_ctseg {
     h5_read(grp, "measure_state_hist", c.measure_state_hist);
     h5_read(grp, "measure_g2w", c.measure_g2w);
     h5_read(grp, "measure_g3w", c.measure_g3w);
+    h5_read(grp, "imag_threshold", c.imag_threshold);
     h5_read(grp, "det_init_size", c.det_init_size);
     h5_read(grp, "det_n_operations_before_check", c.det_n_operations_before_check);
     h5_read(grp, "det_precision_warning", c.det_precision_warning);

--- a/c++/triqs_ctseg/params.cpp
+++ b/c++/triqs_ctseg/params.cpp
@@ -128,7 +128,7 @@ namespace triqs_ctseg {
     h5_read(grp, "measure_state_hist", c.measure_state_hist);
     h5_read(grp, "measure_g2w", c.measure_g2w);
     h5_read(grp, "measure_g3w", c.measure_g3w);
-    h5_read(grp, "imag_threshold", c.imag_threshold);
+    h5::try_read(grp, "imag_threshold", c.imag_threshold);
     h5_read(grp, "det_init_size", c.det_init_size);
     h5_read(grp, "det_n_operations_before_check", c.det_n_operations_before_check);
     h5_read(grp, "det_precision_warning", c.det_precision_warning);

--- a/c++/triqs_ctseg/params.hpp
+++ b/c++/triqs_ctseg/params.hpp
@@ -156,6 +156,11 @@ namespace triqs_ctseg {
 
     // -------- Misc parameters --------------
 
+    /// Tolerance on the imaginary part of the local Hamiltonian h_loc0 (CT-SEG uses a real
+    /// h_loc0). Below it the imaginary part is dropped silently, up to 1e-6 with a warning,
+    /// above 1e-6 it errors. Raise to accept a larger imaginary part.
+    double imag_threshold = 1.e-13;
+
     /// The maximum size of the determinant matrix before a resize.
     int det_init_size = 100;
 

--- a/c++/triqs_ctseg/params.hpp
+++ b/c++/triqs_ctseg/params.hpp
@@ -156,9 +156,9 @@ namespace triqs_ctseg {
 
     // -------- Misc parameters --------------
 
-    /// Tolerance on the imaginary part of the local Hamiltonian h_loc0 (CT-SEG uses a real
-    /// h_loc0). Below it the imaginary part is dropped silently, up to 1e-6 with a warning,
-    /// above 1e-6 it errors. Raise to accept a larger imaginary part.
+    /// Threshold below which the imaginary part of the local Hamiltonian h_loc0 is set to zero
+    /// (CT-SEG uses a real h_loc0); above it the solver errors. Raise to accept a larger
+    /// imaginary part.
     double imag_threshold = 1.e-13;
 
     /// The maximum size of the determinant matrix before a resize.

--- a/c++/triqs_ctseg/work_data.cpp
+++ b/c++/triqs_ctseg/work_data.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <cmath>
 #include <complex>
-#include <vector>
 #include <nda/basic_functions.hpp>
 #include <nda/traits.hpp>
 #include <triqs/gfs/functions/functions2.hpp>

--- a/c++/triqs_ctseg/work_data.cpp
+++ b/c++/triqs_ctseg/work_data.cpp
@@ -57,25 +57,16 @@ namespace triqs_ctseg {
     // h_loc0 coefficients are stored as real_or_complex and are flagged complex whenever
     // h_loc0 is built from complex matrices (e.g. a downfolded DFT Hamiltonian), even when
     // the imaginary part is numerical noise. CT-SEG (segment picture) uses a real local
-    // Hamiltonian, so discard a small imaginary part on the diagonal silently, warn for a
-    // larger one (still taking the real part), and error out only if it is so large that the
-    // input is genuinely complex.
+    // Hamiltonian, so set the imaginary part of the diagonal to zero when it is below
+    // imag_threshold and error out otherwise (same convention as cthyb).
     mu          = nda::zeros<double>(n_color);
     auto h_loc0 = dict_to_matrix<std::complex<double>>(extract_h_dict(p.h_loc0), p.gf_struct);
 
-    constexpr double imag_error_threshold = 1.e-6;
-    double max_imag                       = 0.0;
+    double max_imag = 0.0;
     for (auto const &col : range(n_color)) max_imag = std::max(max_imag, std::abs(h_loc0(col, col).imag()));
-    if (max_imag > p.imag_threshold) {
-      if (max_imag > imag_error_threshold)
-        TRIQS_RUNTIME_ERROR << "work_data: the local Hamiltonian h_loc0 has an imaginary part on its diagonal (max |Im| = "
-                            << max_imag << ") larger than " << imag_error_threshold
-                            << ". CT-SEG requires a real local Hamiltonian.";
-      if (c.rank() == 0)
-        spdlog::warn("Imaginary part on the h_loc0 diagonal (max |Im| = {:.3e}) exceeds imag_threshold ({:.3e}); "
-                     "discarding it and taking the real part.",
-                     max_imag, p.imag_threshold);
-    }
+    if (max_imag > p.imag_threshold)
+      TRIQS_RUNTIME_ERROR << "Largest imaginary element of the h_loc0 diagonal: " << max_imag
+                          << ", is larger than the set parameter imag_threshold " << p.imag_threshold;
     for (auto const &col : range(n_color)) mu(col) = -h_loc0(col, col).real();
 
     // .............. Interactions .................

--- a/c++/triqs_ctseg/work_data.cpp
+++ b/c++/triqs_ctseg/work_data.cpp
@@ -5,10 +5,15 @@
 // See LICENSE in the root of this distribution for details.
 
 #include "work_data.hpp"
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
 #include <nda/basic_functions.hpp>
 #include <nda/traits.hpp>
 #include <triqs/gfs/functions/functions2.hpp>
 #include <triqs/operators/util/extractors.hpp>
+#include <triqs/utility/exceptions.hpp>
 #include "logs.hpp"
 #include "spdlog/common.h"
 #include "spdlog/spdlog.h"
@@ -49,10 +54,30 @@ namespace triqs_ctseg {
       }
     }
 
-    // Extract color-dependent chemical potential from operator
+    // Extract color-dependent chemical potential from the local Hamiltonian operator.
+    // h_loc0 coefficients are stored as real_or_complex and are flagged complex whenever
+    // h_loc0 is built from complex matrices (e.g. a downfolded DFT Hamiltonian), even when
+    // the imaginary part is numerical noise. CT-SEG (segment picture) uses a real local
+    // Hamiltonian, so discard a small imaginary part on the diagonal silently, warn for a
+    // larger one (still taking the real part), and error out only if it is so large that the
+    // input is genuinely complex.
     mu          = nda::zeros<double>(n_color);
-    auto h_loc0 = dict_to_matrix(extract_h_dict(p.h_loc0), p.gf_struct);
-    for (auto const &col : range(n_color)) { mu(col) = -h_loc0(col, col); }
+    auto h_loc0 = dict_to_matrix<std::complex<double>>(extract_h_dict(p.h_loc0), p.gf_struct);
+
+    constexpr double imag_error_threshold = 1.e-6;
+    double max_imag                       = 0.0;
+    for (auto const &col : range(n_color)) max_imag = std::max(max_imag, std::abs(h_loc0(col, col).imag()));
+    if (max_imag > p.imag_threshold) {
+      if (max_imag > imag_error_threshold)
+        TRIQS_RUNTIME_ERROR << "work_data: the local Hamiltonian h_loc0 has an imaginary part on its diagonal (max |Im| = "
+                            << max_imag << ") larger than " << imag_error_threshold
+                            << ". CT-SEG requires a real local Hamiltonian.";
+      if (c.rank() == 0)
+        spdlog::warn("Imaginary part on the h_loc0 diagonal (max |Im| = {:.3e}) exceeds imag_threshold ({:.3e}); "
+                     "discarding it and taking the real part.",
+                     max_imag, p.imag_threshold);
+    }
+    for (auto const &col : range(n_color)) mu(col) = -h_loc0(col, col).real();
 
     // .............. Interactions .................
     // Extract the U from the operator

--- a/python/triqs_ctseg/solver_core.wrap.cxx
+++ b/python/triqs_ctseg/solver_core.wrap.cxx
@@ -383,9 +383,9 @@ constexpr auto _c2py_doc_member_40 = R"DOC(Whether to measure state histograms.)
 constexpr auto _c2py_doc_member_41 = R"DOC(Whether to measure three-point correlation function.)DOC";
 constexpr auto _c2py_doc_member_42 = R"DOC(Whether to measure four-point correlation function.)DOC";
 constexpr auto _c2py_doc_member_43 =
-   R"DOC(Tolerance on the imaginary part of the local Hamiltonian h_loc0 (CT-SEG uses a real
-h_loc0). Below it the imaginary part is dropped silently, up to 1e-6 with a warning,
-above 1e-6 it errors. Raise to accept a larger imaginary part.)DOC";
+   R"DOC(Threshold below which the imaginary part of the local Hamiltonian h_loc0 is set to zero
+(CT-SEG uses a real h_loc0); above it the solver errors. Raise to accept a larger
+imaginary part.)DOC";
 constexpr auto _c2py_doc_member_44 = R"DOC(The maximum size of the determinant matrix before a resize.)DOC";
 constexpr auto _c2py_doc_member_45 =
    R"DOC(Max number of ops before testing the accuracy of :math:`\det(M)` and :math:`M^{-1}`.)DOC";

--- a/python/triqs_ctseg/solver_core.wrap.cxx
+++ b/python/triqs_ctseg/solver_core.wrap.cxx
@@ -168,6 +168,7 @@ static int synth_constructor_1(PyObject *self, PyObject *args, PyObject *kwargs)
   de("measure_state_hist", self_c.measure_state_hist, true);
   de("measure_g2w", self_c.measure_g2w, true);
   de("measure_g3w", self_c.measure_g3w, true);
+  de("imag_threshold", self_c.imag_threshold, true);
   de("det_init_size", self_c.det_init_size, true);
   de("det_n_operations_before_check", self_c.det_n_operations_before_check, true);
   de("det_precision_warning", self_c.det_precision_warning, true);
@@ -264,19 +265,21 @@ measure_g2w : {par_37}, default=false
 
 measure_g3w : {par_38}, default=false
 
-det_init_size : {par_39}, default=100
+imag_threshold : {par_39}, default=1.e-13
 
-det_n_operations_before_check : {par_40}, default=100
+det_init_size : {par_40}, default=100
 
-det_precision_warning : {par_41}, default=1.e-8
+det_n_operations_before_check : {par_41}, default=100
 
-det_precision_error : {par_42}, default=1.e-5
+det_precision_warning : {par_42}, default=1.e-8
 
-det_singular_threshold : {par_43}, default=-1
+det_precision_error : {par_43}, default=1.e-5
 
-histogram_max_order : {par_44}, default=1000
+det_singular_threshold : {par_44}, default=-1
 
-visualize_config : {par_45}, default=false
+histogram_max_order : {par_45}, default=1000
+
+visualize_config : {par_46}, default=false
 
 )DOC",
                       "par",
@@ -319,6 +322,7 @@ visualize_config : {par_45}, default=false
                        c2py::python_typename<bool>(),
                        c2py::python_typename<bool>(),
                        c2py::python_typename<bool>(),
+                       c2py::python_typename<double>(),
                        c2py::python_typename<int>(),
                        c2py::python_typename<int>(),
                        c2py::python_typename<double>(),
@@ -378,15 +382,19 @@ constexpr auto _c2py_doc_member_39 = R"DOC(Whether to measure :math:`\langle S_x
 constexpr auto _c2py_doc_member_40 = R"DOC(Whether to measure state histograms.)DOC";
 constexpr auto _c2py_doc_member_41 = R"DOC(Whether to measure three-point correlation function.)DOC";
 constexpr auto _c2py_doc_member_42 = R"DOC(Whether to measure four-point correlation function.)DOC";
-constexpr auto _c2py_doc_member_43 = R"DOC(The maximum size of the determinant matrix before a resize.)DOC";
-constexpr auto _c2py_doc_member_44 =
+constexpr auto _c2py_doc_member_43 =
+   R"DOC(Tolerance on the imaginary part of the local Hamiltonian h_loc0 (CT-SEG uses a real
+h_loc0). Below it the imaginary part is dropped silently, up to 1e-6 with a warning,
+above 1e-6 it errors. Raise to accept a larger imaginary part.)DOC";
+constexpr auto _c2py_doc_member_44 = R"DOC(The maximum size of the determinant matrix before a resize.)DOC";
+constexpr auto _c2py_doc_member_45 =
    R"DOC(Max number of ops before testing the accuracy of :math:`\det(M)` and :math:`M^{-1}`.)DOC";
-constexpr auto _c2py_doc_member_45 = R"DOC(Threshold for determinant precision warnings.)DOC";
-constexpr auto _c2py_doc_member_46 = R"DOC(Threshold for determinant precision error.)DOC";
-constexpr auto _c2py_doc_member_47 =
+constexpr auto _c2py_doc_member_46 = R"DOC(Threshold for determinant precision warnings.)DOC";
+constexpr auto _c2py_doc_member_47 = R"DOC(Threshold for determinant precision error.)DOC";
+constexpr auto _c2py_doc_member_48 =
    R"DOC(Bound for the determinant matrix being singular (if :math:`< 0`, checks for subnormal numbers).)DOC";
-constexpr auto _c2py_doc_member_48 = R"DOC(Maximum order for the perturbation order histograms.)DOC";
-constexpr auto _c2py_doc_member_49 = R"DOC(Output characteristic configurations in a separate file.)DOC";
+constexpr auto _c2py_doc_member_49 = R"DOC(Maximum order for the perturbation order histograms.)DOC";
+constexpr auto _c2py_doc_member_50 = R"DOC(Output characteristic configurations in a separate file.)DOC";
 static PyObject *prop_get_dict_1(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_1> *)self)->_c);
   c2py::pydict dic;
@@ -429,6 +437,7 @@ static PyObject *prop_get_dict_1(PyObject *self, void *) {
   dic["measure_state_hist"]            = self_c.measure_state_hist;
   dic["measure_g2w"]                   = self_c.measure_g2w;
   dic["measure_g3w"]                   = self_c.measure_g3w;
+  dic["imag_threshold"]                = self_c.imag_threshold;
   dic["det_init_size"]                 = self_c.det_init_size;
   dic["det_n_operations_before_check"] = self_c.det_n_operations_before_check;
   dic["det_precision_warning"]         = self_c.det_precision_warning;
@@ -496,18 +505,19 @@ constinit PyGetSetDef c2py::tp_getset<_c2py_cls_1>[] = {
                                                                               _c2py_doc_member_40),
    c2py::getsetdef_from_member<&_c2py_cls_1::measure_g2w, _c2py_cls_1>("measure_g2w", _c2py_doc_member_41),
    c2py::getsetdef_from_member<&_c2py_cls_1::measure_g3w, _c2py_cls_1>("measure_g3w", _c2py_doc_member_42),
-   c2py::getsetdef_from_member<&_c2py_cls_1::det_init_size, _c2py_cls_1>("det_init_size", _c2py_doc_member_43),
+   c2py::getsetdef_from_member<&_c2py_cls_1::imag_threshold, _c2py_cls_1>("imag_threshold", _c2py_doc_member_43),
+   c2py::getsetdef_from_member<&_c2py_cls_1::det_init_size, _c2py_cls_1>("det_init_size", _c2py_doc_member_44),
    c2py::getsetdef_from_member<&_c2py_cls_1::det_n_operations_before_check, _c2py_cls_1>(
-      "det_n_operations_before_check", _c2py_doc_member_44),
+      "det_n_operations_before_check", _c2py_doc_member_45),
    c2py::getsetdef_from_member<&_c2py_cls_1::det_precision_warning, _c2py_cls_1>("det_precision_warning",
-                                                                                 _c2py_doc_member_45),
+                                                                                 _c2py_doc_member_46),
    c2py::getsetdef_from_member<&_c2py_cls_1::det_precision_error, _c2py_cls_1>("det_precision_error",
-                                                                               _c2py_doc_member_46),
+                                                                               _c2py_doc_member_47),
    c2py::getsetdef_from_member<&_c2py_cls_1::det_singular_threshold, _c2py_cls_1>("det_singular_threshold",
-                                                                                  _c2py_doc_member_47),
+                                                                                  _c2py_doc_member_48),
    c2py::getsetdef_from_member<&_c2py_cls_1::histogram_max_order, _c2py_cls_1>("histogram_max_order",
-                                                                               _c2py_doc_member_48),
-   c2py::getsetdef_from_member<&_c2py_cls_1::visualize_config, _c2py_cls_1>("visualize_config", _c2py_doc_member_49),
+                                                                               _c2py_doc_member_49),
+   c2py::getsetdef_from_member<&_c2py_cls_1::visualize_config, _c2py_cls_1>("visualize_config", _c2py_doc_member_50),
    {"__dict__", (getter)prop_get_dict_1, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -627,25 +637,25 @@ PyMethodDef c2py::tp_methods<_c2py_cls_2>[] = {
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
-constexpr auto _c2py_doc_member_50 = R"DOC(Single-particle Green's function :math:`G(\tau)`.)DOC";
-constexpr auto _c2py_doc_member_51 = R"DOC(Self-energy improved estimator :math:`F(\tau)`.)DOC";
-constexpr auto _c2py_doc_member_52 =
-   R"DOC(Density-density time correlation function :math:`\langle n_a(\tau) n_b(0) \rangle`.)DOC";
+constexpr auto _c2py_doc_member_51 = R"DOC(Single-particle Green's function :math:`G(\tau)`.)DOC";
+constexpr auto _c2py_doc_member_52 = R"DOC(Self-energy improved estimator :math:`F(\tau)`.)DOC";
 constexpr auto _c2py_doc_member_53 =
-   R"DOC(Density-density frequency correlation function :math:`\langle n_a(i\nu) n_b(-i\nu) \rangle`.)DOC";
+   R"DOC(Density-density time correlation function :math:`\langle n_a(\tau) n_b(0) \rangle`.)DOC";
 constexpr auto _c2py_doc_member_54 =
-   R"DOC(Perpendicular spin-spin correlation function :math:`\langle S_x(\tau) S_x(0) \rangle`.)DOC";
+   R"DOC(Density-density frequency correlation function :math:`\langle n_a(i\nu) n_b(-i\nu) \rangle`.)DOC";
 constexpr auto _c2py_doc_member_55 =
+   R"DOC(Perpendicular spin-spin correlation function :math:`\langle S_x(\tau) S_x(0) \rangle`.)DOC";
+constexpr auto _c2py_doc_member_56 =
    R"DOC(Density-density static correlation function :math:`\langle n_a(0) n_b(0) \rangle`.)DOC";
-constexpr auto _c2py_doc_member_56 = R"DOC(Density per color, organized by blocks.)DOC";
-constexpr auto _c2py_doc_member_57 = R"DOC(Delta perturbation order histogram.)DOC";
-constexpr auto _c2py_doc_member_58 = R"DOC(Average Delta perturbation order.)DOC";
-constexpr auto _c2py_doc_member_59 = R"DOC(Jperp perturbation order histogram.)DOC";
-constexpr auto _c2py_doc_member_60 = R"DOC(Average Jperp perturbation order.)DOC";
-constexpr auto _c2py_doc_member_61 = R"DOC(State histogram.)DOC";
-constexpr auto _c2py_doc_member_62 = R"DOC(Three-point correlation function.)DOC";
-constexpr auto _c2py_doc_member_63 = R"DOC(Four-point correlation function.)DOC";
-constexpr auto _c2py_doc_member_64 = R"DOC(Average sign.)DOC";
+constexpr auto _c2py_doc_member_57 = R"DOC(Density per color, organized by blocks.)DOC";
+constexpr auto _c2py_doc_member_58 = R"DOC(Delta perturbation order histogram.)DOC";
+constexpr auto _c2py_doc_member_59 = R"DOC(Average Delta perturbation order.)DOC";
+constexpr auto _c2py_doc_member_60 = R"DOC(Jperp perturbation order histogram.)DOC";
+constexpr auto _c2py_doc_member_61 = R"DOC(Average Jperp perturbation order.)DOC";
+constexpr auto _c2py_doc_member_62 = R"DOC(State histogram.)DOC";
+constexpr auto _c2py_doc_member_63 = R"DOC(Three-point correlation function.)DOC";
+constexpr auto _c2py_doc_member_64 = R"DOC(Four-point correlation function.)DOC";
+constexpr auto _c2py_doc_member_65 = R"DOC(Average sign.)DOC";
 static PyObject *prop_get_dict_2(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_2> *)self)->_c);
   c2py::pydict dic;
@@ -671,23 +681,23 @@ static PyObject *prop_get_dict_2(PyObject *self, void *) {
 
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_2>[] = {
-   c2py::getsetdef_from_member<&_c2py_cls_2::G_tau, _c2py_cls_2>("G_tau", _c2py_doc_member_50),
-   c2py::getsetdef_from_member<&_c2py_cls_2::F_tau, _c2py_cls_2>("F_tau", _c2py_doc_member_51),
-   c2py::getsetdef_from_member<&_c2py_cls_2::nn_tau, _c2py_cls_2>("nn_tau", _c2py_doc_member_52),
-   c2py::getsetdef_from_member<&_c2py_cls_2::nn_nu_dlr, _c2py_cls_2>("nn_nu_dlr", _c2py_doc_member_53),
-   c2py::getsetdef_from_member<&_c2py_cls_2::Sperp_tau, _c2py_cls_2>("Sperp_tau", _c2py_doc_member_54),
-   c2py::getsetdef_from_member<&_c2py_cls_2::nn_static, _c2py_cls_2>("nn_static", _c2py_doc_member_55),
-   c2py::getsetdef_from_member<&_c2py_cls_2::densities, _c2py_cls_2>("densities", _c2py_doc_member_56),
-   c2py::getsetdef_from_member<&_c2py_cls_2::pert_order_Delta, _c2py_cls_2>("pert_order_Delta", _c2py_doc_member_57),
+   c2py::getsetdef_from_member<&_c2py_cls_2::G_tau, _c2py_cls_2>("G_tau", _c2py_doc_member_51),
+   c2py::getsetdef_from_member<&_c2py_cls_2::F_tau, _c2py_cls_2>("F_tau", _c2py_doc_member_52),
+   c2py::getsetdef_from_member<&_c2py_cls_2::nn_tau, _c2py_cls_2>("nn_tau", _c2py_doc_member_53),
+   c2py::getsetdef_from_member<&_c2py_cls_2::nn_nu_dlr, _c2py_cls_2>("nn_nu_dlr", _c2py_doc_member_54),
+   c2py::getsetdef_from_member<&_c2py_cls_2::Sperp_tau, _c2py_cls_2>("Sperp_tau", _c2py_doc_member_55),
+   c2py::getsetdef_from_member<&_c2py_cls_2::nn_static, _c2py_cls_2>("nn_static", _c2py_doc_member_56),
+   c2py::getsetdef_from_member<&_c2py_cls_2::densities, _c2py_cls_2>("densities", _c2py_doc_member_57),
+   c2py::getsetdef_from_member<&_c2py_cls_2::pert_order_Delta, _c2py_cls_2>("pert_order_Delta", _c2py_doc_member_58),
    c2py::getsetdef_from_member<&_c2py_cls_2::average_order_Delta, _c2py_cls_2>("average_order_Delta",
-                                                                               _c2py_doc_member_58),
-   c2py::getsetdef_from_member<&_c2py_cls_2::pert_order_Jperp, _c2py_cls_2>("pert_order_Jperp", _c2py_doc_member_59),
+                                                                               _c2py_doc_member_59),
+   c2py::getsetdef_from_member<&_c2py_cls_2::pert_order_Jperp, _c2py_cls_2>("pert_order_Jperp", _c2py_doc_member_60),
    c2py::getsetdef_from_member<&_c2py_cls_2::average_order_Jperp, _c2py_cls_2>("average_order_Jperp",
-                                                                               _c2py_doc_member_60),
-   c2py::getsetdef_from_member<&_c2py_cls_2::state_hist, _c2py_cls_2>("state_hist", _c2py_doc_member_61),
-   c2py::getsetdef_from_member<&_c2py_cls_2::g2w, _c2py_cls_2>("g2w", _c2py_doc_member_62),
-   c2py::getsetdef_from_member<&_c2py_cls_2::g3w, _c2py_cls_2>("g3w", _c2py_doc_member_63),
-   c2py::getsetdef_from_member<&_c2py_cls_2::average_sign, _c2py_cls_2>("average_sign", _c2py_doc_member_64),
+                                                                               _c2py_doc_member_61),
+   c2py::getsetdef_from_member<&_c2py_cls_2::state_hist, _c2py_cls_2>("state_hist", _c2py_doc_member_62),
+   c2py::getsetdef_from_member<&_c2py_cls_2::g2w, _c2py_cls_2>("g2w", _c2py_doc_member_63),
+   c2py::getsetdef_from_member<&_c2py_cls_2::g3w, _c2py_cls_2>("g3w", _c2py_doc_member_64),
+   c2py::getsetdef_from_member<&_c2py_cls_2::average_sign, _c2py_cls_2>("average_sign", _c2py_doc_member_65),
    {"__dict__", (getter)prop_get_dict_2, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -737,9 +747,9 @@ PyMethodDef c2py::tp_methods<_c2py_cls_3>[] = {
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
-constexpr auto _c2py_doc_member_65 = R"DOC(Parameters used for constructing the solver.)DOC";
-constexpr auto _c2py_doc_member_66 = R"DOC(Parameters passed to the ``solve()`` method.)DOC";
-constexpr auto _c2py_doc_member_67 = R"DOC(Container for all results accumulated by the CTQMC simulation.)DOC";
+constexpr auto _c2py_doc_member_66 = R"DOC(Parameters used for constructing the solver.)DOC";
+constexpr auto _c2py_doc_member_67 = R"DOC(Parameters passed to the ``solve()`` method.)DOC";
+constexpr auto _c2py_doc_member_68 = R"DOC(Container for all results accumulated by the CTQMC simulation.)DOC";
 static constexpr auto prop_doc_0   = R"DOC(Dynamical density-density interaction :math:`D_0(\tau)`.)DOC";
 static constexpr auto prop_doc_1   = R"DOC(Hybridization function :math:`\Delta(\tau)`.)DOC";
 static constexpr auto prop_doc_2   = R"DOC(Dynamical spin-spin interaction :math:`\mathcal{J}_\perp(\tau)`.)DOC";
@@ -748,9 +758,9 @@ static constexpr auto prop_doc_2   = R"DOC(Dynamical spin-spin interaction :math
 
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_3>[] = {
-   c2py::getsetdef_from_member<&_c2py_cls_3::constr_params, _c2py_cls_3>("constr_params", _c2py_doc_member_65),
-   c2py::getsetdef_from_member<&_c2py_cls_3::solve_params, _c2py_cls_3>("solve_params", _c2py_doc_member_66),
-   c2py::getsetdef_from_member<&_c2py_cls_3::results, _c2py_cls_3>("results", _c2py_doc_member_67),
+   c2py::getsetdef_from_member<&_c2py_cls_3::constr_params, _c2py_cls_3>("constr_params", _c2py_doc_member_66),
+   c2py::getsetdef_from_member<&_c2py_cls_3::solve_params, _c2py_cls_3>("solve_params", _c2py_doc_member_67),
+   c2py::getsetdef_from_member<&_c2py_cls_3::results, _c2py_cls_3>("results", _c2py_doc_member_68),
    {"D0_tau", c2py::getter_from_method<c2py::castm<>(&triqs_ctseg::solver_core::D0_tau)>, nullptr, prop_doc_0, nullptr},
    {"Delta_tau", c2py::getter_from_method<c2py::castm<>(&triqs_ctseg::solver_core::Delta_tau)>, nullptr, prop_doc_1,
     nullptr},

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -7,6 +7,7 @@ endforeach()
 # List of all tests
 set(all_tests
   ./anderson
+  ./complex_h_loc0
   ./dynamical_U
   ./Jperp
   ./spin_spin

--- a/test/python/complex_h_loc0.py
+++ b/test/python/complex_h_loc0.py
@@ -38,7 +38,7 @@ S_real = make_solver()
 S_real.solve(h_loc0=-mu * (n("up", 0) + n("down", 0)), **base)
 
 # Complex-typed h_loc0 with a negligible imaginary part: the imaginary part must be dropped,
-# reproducing the real run bit-for-bit (same coefficients, same seed -> same Markov chain).
+# reproducing the real run (identical real coefficients, same seed -> same Markov chain).
 S_cplx = make_solver()
 S_cplx.solve(h_loc0=complex(-mu, 1e-15) * (n("up", 0) + n("down", 0)), **base)
 

--- a/test/python/complex_h_loc0.py
+++ b/test/python/complex_h_loc0.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2024--present, The Simons Foundation
+# Copyright (c) 2024--present, Max Planck Institute for Polymer Research, Mainz, Germany
+# This file is part of TRIQS/ctseg and is licensed under the terms of GPLv3 or later.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See LICENSE in the root of this distribution for details.
+
+# h_loc0 built from complex matrices carries complex-flagged coefficients (real_or_complex)
+# even when the imaginary part is numerical noise. CT-SEG uses a real local Hamiltonian:
+#  - a negligible imaginary part on the diagonal must be dropped (taking the real part), so a
+#    complex-typed h_loc0 reproduces the equivalent real one exactly;
+#  - a genuinely complex h_loc0 (imaginary part above imag_threshold's hard limit) must error.
+from triqs.gfs import *
+import triqs.utility.mpi as mpi
+from triqs.operators import n
+from triqs.gfs import iOmega_n
+from triqs.utility.h5diff import h5diff
+import h5
+from triqs_ctseg import Solver
+
+beta, U, mu, eps, n_tau, n_tau_bosonic = 10, 4.0, 2.0, 0.2, 2051, 2001
+constr_params = {"gf_struct": [('down', 1), ('up', 1)], "beta": beta,
+                 "n_tau": n_tau, "n_tau_bosonic": n_tau_bosonic}
+
+def make_solver():
+    S = Solver(**constr_params)
+    iw_mesh = MeshImFreq(beta, 'Fermion', n_tau // 2)
+    delta_iw = GfImFreq(indices=[0], mesh=iw_mesh)
+    delta_iw << inverse(iOmega_n - eps)
+    S.Delta_tau["up"] << Fourier(delta_iw)
+    S.Delta_tau["down"] << Fourier(delta_iw)
+    return S
+
+base = {"h_int": U * n("up", 0) * n("down", 0), "length_cycle": 50,
+        "n_warmup_cycles": 100, "n_cycles": 500, "random_seed": 42, "measure_F_tau": True}
+
+# Real h_loc0
+S_real = make_solver()
+S_real.solve(h_loc0=-mu * (n("up", 0) + n("down", 0)), **base)
+
+# Complex-typed h_loc0 with a negligible imaginary part: the imaginary part must be dropped,
+# reproducing the real run bit-for-bit (same coefficients, same seed -> same Markov chain).
+S_cplx = make_solver()
+S_cplx.solve(h_loc0=complex(-mu, 1e-15) * (n("up", 0) + n("down", 0)), **base)
+
+if mpi.is_master_node():
+    with h5.HDFArchive("complex_h_loc0_real.h5", 'w') as A:
+        A['G_tau'] = S_real.results.G_tau
+        A['F_tau'] = S_real.results.F_tau
+        A['densities'] = S_real.results.densities
+    with h5.HDFArchive("complex_h_loc0_cplx.h5", 'w') as A:
+        A['G_tau'] = S_cplx.results.G_tau
+        A['F_tau'] = S_cplx.results.F_tau
+        A['densities'] = S_cplx.results.densities
+    h5diff("complex_h_loc0_cplx.h5", "complex_h_loc0_real.h5", precision=1e-10)
+
+# A genuinely complex h_loc0 (imaginary part above the hard limit) must raise.
+raised = False
+try:
+    S_bad = make_solver()
+    S_bad.solve(h_loc0=complex(-mu, 1e-3) * (n("up", 0) + n("down", 0)), **base)
+except RuntimeError:
+    raised = True
+assert raised, "a genuinely complex h_loc0 (Im = 1e-3) should raise an error"
+
+# imag_threshold is tunable: raising it above the imaginary part accepts it silently.
+S_tuned = make_solver()
+S_tuned.solve(h_loc0=complex(-mu, 1e-9) * (n("up", 0) + n("down", 0)), imag_threshold=1e-8, **base)

--- a/test/python/complex_h_loc0.py
+++ b/test/python/complex_h_loc0.py
@@ -6,9 +6,9 @@
 
 # h_loc0 built from complex matrices carries complex-flagged coefficients (real_or_complex)
 # even when the imaginary part is numerical noise. CT-SEG uses a real local Hamiltonian:
-#  - a negligible imaginary part on the diagonal must be dropped (taking the real part), so a
-#    complex-typed h_loc0 reproduces the equivalent real one exactly;
-#  - a genuinely complex h_loc0 (imaginary part above imag_threshold's hard limit) must error.
+#  - an imaginary part on the diagonal below imag_threshold must be dropped (taking the real
+#    part), so a complex-typed h_loc0 reproduces the equivalent real one exactly;
+#  - an imaginary part above imag_threshold must error.
 from triqs.gfs import *
 import triqs.utility.mpi as mpi
 from triqs.operators import n
@@ -53,14 +53,14 @@ if mpi.is_master_node():
         A['densities'] = S_cplx.results.densities
     h5diff("complex_h_loc0_cplx.h5", "complex_h_loc0_real.h5", precision=1e-10)
 
-# A genuinely complex h_loc0 (imaginary part above the hard limit) must raise.
+# An imaginary part above imag_threshold (default 1e-13) must raise.
 raised = False
 try:
     S_bad = make_solver()
     S_bad.solve(h_loc0=complex(-mu, 1e-3) * (n("up", 0) + n("down", 0)), **base)
 except RuntimeError:
     raised = True
-assert raised, "a genuinely complex h_loc0 (Im = 1e-3) should raise an error"
+assert raised, "an h_loc0 with Im = 1e-3 > imag_threshold should raise an error"
 
 # imag_threshold is tunable: raising it above the imaginary part accepts it silently.
 S_tuned = make_solver()


### PR DESCRIPTION
## Problem

Passing an `h_loc0` built from complex matrices (e.g. a downfolded DFT Hamiltonian) fails with

```
Triqs runtime error at .../real_or_complex.hpp : Logic error : the number is not real, it is complex
```

even when the imaginary part is numerical noise. `h_loc0`'s coefficients are stored as
`real_or_complex`; `work_data` extracted them with `dict_to_matrix` defaulting to a `double`
target, which converts each coefficient through `real_or_complex::operator double()` — and that
throws on any value *flagged* complex, regardless of the actual magnitude of the imaginary part.

## Fix

Extract `h_loc0` as `std::complex<double>` (a non-throwing conversion) and take the real part of
the diagonal for the chemical potential, with a tiered tolerance on the imaginary part:

- `|Im| <= imag_threshold` &rarr; silently dropped
- `imag_threshold < |Im| <= 1e-6` &rarr; warning, real part still used
- `|Im| > 1e-6` &rarr; error (genuinely complex local Hamiltonian)

A new `imag_threshold` solve parameter (default `1e-13`) makes the tolerance tunable.

This mirrors how **cthyb** handles complex input when built without complex support (same
`imag_threshold` parameter and default).

Adds `test/python/complex_h_loc0`.
