### PR TITLE
fix(tests): Loosen the tolerance of solve_generic on MeshDLRImFreq

### DIFF
--- a/test/python/solve_generic_dlr.py
+++ b/test/python/solve_generic_dlr.py
@@ -73,4 +73,4 @@ if mpi.is_master_node():
         A['Sigma_HartreeFock'] = results.Sigma_HartreeFock
         A['densities'] = results.Solver.results.densities
 
-    h5diff("solve_generic_dlr.out.h5", "solve_generic_dlr.ref.h5", precision=2e-9)
+    h5diff("solve_generic_dlr.out.h5", "solve_generic_dlr.ref.h5", precision=3e-9)


### PR DESCRIPTION
With AVX-512 enabled the test fails with a difference just slightly above 2e-9.

    Comparison of key '/Sigma_dynamic'  has failed:
     Arrays are different. Difference is 2.0874738633602023e-09.